### PR TITLE
Added www.* to host file automatically

### DIFF
--- a/bin/noprocrast
+++ b/bin/noprocrast
@@ -2,6 +2,15 @@
 
 require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'lib', 'noprocrast')
 
+acceptable = "[on|off|status|edit]"
+message = "Usage: [sudo] noprocrast #{acceptable}"
+
+# Bail immediately if inputs are wrong
+if ARGV.length > 1 then
+  puts message
+  exit
+end
+
 begin
 	case ARGV.first
 	when 'on', 'reload'
@@ -22,7 +31,9 @@ begin
 			puts "Saved. Now: noprocrast on"
 		end
 	when 'help', '-h', '--help', nil
-		puts "Usage: [sudo] noprocrast [on|off|status|edit]"
+		puts message
+        else
+                puts "Error: bad input.\n#{message}"
 	end
 rescue Errno::EACCES
 	puts "Permission denied: try sudo noprocrast"

--- a/lib/noprocrast.rb
+++ b/lib/noprocrast.rb
@@ -12,7 +12,9 @@ class Noprocrast
 
 		def current_hosts
 			setup_deny_file_if_required!
-			File.read(deny_file_path).split(/\n/).select { |line| line.match(/[a-zA-Z0-9]/) }.map(&:strip)
+			hosts = File.read(deny_file_path).split(/\n/).select { |line| line.match(/[a-zA-Z0-9]/) }.map(&:strip)
+                        wwwhosts = hosts.map { |h| "www." + h.to_s unless h =~ /^www/ }
+                        (hosts + wwwhosts).sort
 		end
 
 		def hosts_file_content


### PR DESCRIPTION
Hi! I found your noprocrast library a couple of months ago and it's been a huge help for me.

I noticed, though, that it doesn't automatically block "www" addresses. For example, when I type "reddit.com" into Chrome, it automatically sends me to "www.reddit.com" which isn't blocked if I only entered "reddit.com" into the .noprocrast file.

I added a couple of lines to the current_hosts method to automatically add a "www" entry for any lines that don't have one already.
